### PR TITLE
Issue #34: edit this page button

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,72 @@
+name: "🐛 Bug Report"
+description: Report a bug.
+title: "🐛 [BUG] - <title>"
+labels: [
+  "bug"
+]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: Please enter an explicit description of the issue
+      placeholder: Short and explicit description of the incident...
+    validations:
+      required: true
+  - type: textarea
+    id: reprod
+    attributes:
+      label: "Reproduction steps"
+      description: Please enter an explicit description of your issue
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: "Screenshots"
+      description: If applicable, add screenshots/videos to help explain your problem.
+      value: |
+        ![DESCRIPTION](LINK.png)
+      render: bash
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs"
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: bash
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: "Browsers"
+      description: What browsers are you seeing the problem on ?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: "OS"
+      description: What is the impacted environment ?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - Mac
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,39 @@
+name: "💡 Feature Request"
+description: Create a new feature request
+title: "💡 [REQUEST] - <title>"
+labels: [
+  "enhancement"
+]
+body:
+  - type: textarea
+    id: implementation_pr
+    attributes:
+      label: "Implementation PR"
+      description: If you have a PR that implements this feature list it below
+      placeholder: "#PullRequestID"
+    validations:
+      required: false
+  - type: textarea
+    id: reference_issues
+    attributes:
+      label: "Reference Issue(s)"
+      description: List the issue(s) that are related to this feature request
+      placeholder: "Closes #IssueID"
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: Provide a brief explanation of the feature
+      placeholder: Describe in a few lines your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: unresolved_question
+    attributes:
+      label: "Unresolved questions"
+      description: What questions still remain unresolved ?
+      placeholder: Identify any unresolved issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/SECURITY-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/SECURITY-REPORT.yml
@@ -1,0 +1,60 @@
+name: "⚠️ Security Vulnerability Report"
+description: File a security vulnerability report
+title: "⚠️ [Security] - <title> "
+labels: ["security"]
+assignees:
+  - pi0neerpat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this security vulnerability report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: e.g., email@example.com
+    validations:
+      required: true
+  - type: textarea
+    id: whats-wrong
+    attributes:
+      label: Describe the vulnerability
+      description: A clear and concise description of what the vulnerability is.
+      placeholder: What's wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+      placeholder: |
+        ![DESCRIPTION](LINK.png)
+    validations:
+      required: false
+  - type: dropdown
+    id: devices-affected
+    attributes:
+      label: What devices does this affect?
+      multiple: true
+      options:
+        - All
+        - Windows
+        - macOS
+        - Linux
+        - Android
+        - iOS
+        - Other
+  - type: dropdown
+    id: browsers-affected
+    attributes:
+      label: What browsers does this affect?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/UseKeyp/usekeyp-docs",
+          editUrl: "https://github.com/UseKeyp/usekeyp-docs/tree/main",
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Closes #34 

Description:
- Changed Docusaurus `editUrl` to `https://github.com/UseKeyp/usekeyp-docs/tree/main` so that the edit button will link to the proper page
- Added issue templates to be aligned with our `template-open-source-repo`

Screenshots:
Edit button works now

https://user-images.githubusercontent.com/47253537/213571342-749df4e1-58a4-46d9-aee5-219879ce7051.mov

