### PR TITLE
small title/visual fix

### DIFF
--- a/docs/get-started/get-started.md
+++ b/docs/get-started/get-started.md
@@ -5,7 +5,7 @@ id: my-home-doc
 slug: /
 ---
 
-# 🍩 Welcome to Keyp
+# Welcome to Keyp 🍩
 
 Keyp creates developer tools for game studios and app developers to improve the Web3 onboarding experience.
 


### PR DESCRIPTION
moved the donut to the end of the headline to link donut and Keyp and have more space to make key visible in the title bar