### PR TITLE
Issue #79: Add column for each provider indicating whether email provided

### DIFF
--- a/docs/applications/providers.md
+++ b/docs/applications/providers.md
@@ -9,14 +9,15 @@ We are always adding more providers. Please contact us if you'd like us to add o
 
 ## Currently Available
 
-| Provider   | `ProviderType` | Usernames mutable |
-| ---------- | :------------: | :---------------: |
-| Google     |    `GOOGLE`    |        No         |
-| Discord    |   `DISCORD`    |        Yes        |
-| Twitter    |   `TWITTER`    |        Yes        |
-| Chess.com  |    `CHESS`     |        Yes        |
-| Twitch     |    `TWITCH`    |        Yes        |
-| Epic Games |  `EPIC_GAMES`  |        Yes        |
+| Provider   | `ProviderType` | Usernames mutable | Email provided |
+|------------|:--------------:|:-----------------:|:--------------:|
+| Google     |    `GOOGLE`    |        No         |      Yes       |
+| Discord    |   `DISCORD`    |        Yes        |      Yes       |
+| Twitter    |   `TWITTER`    |        Yes        |       No       |
+| Chess.com  |    `CHESS`     |        Yes        |      Yes       |
+| Twitch     |    `TWITCH`    |        Yes        |      Yes       |
+| Epic Games |  `EPIC_GAMES`  |        Yes        |       No       |
+| Reddit     |    `REDDIT`    |        Yes        |       No       |
 
 ## Planned
 


### PR DESCRIPTION
Closes #79 

## Description
- Added email provided column and added Reddit as a provider


## Screenshots

docs updated

<img width="1440" alt="Screenshot 2023-04-21 at 2 42 51 PM" src="https://user-images.githubusercontent.com/47253537/233712272-b6f11279-c5ac-43a7-871a-4bacde66e0aa.png">

providers with and without emails for reference 
<img width="1006" alt="reference" src="https://user-images.githubusercontent.com/47253537/233712277-d15b2db2-75e4-4a6e-a4de-72def5f67323.png">
