### PR TITLE
Issue #169 (in Keyp App): Add MFA to profile data

### DIFF
--- a/docs/applications/providers.md
+++ b/docs/applications/providers.md
@@ -9,15 +9,17 @@ We are always adding more providers. Please contact us if you'd like us to add o
 
 ## Currently Available
 
-| Provider   | `ProviderType` | Usernames mutable | Email provided |
-|------------|:--------------:|:-----------------:|:--------------:|
-| Google     |    `GOOGLE`    |        No         |      Yes       |
-| Discord    |   `DISCORD`    |        Yes        |      Yes       |
-| Twitter    |   `TWITTER`    |        Yes        |       No       |
-| Chess.com  |    `CHESS`     |        Yes        |      Yes       |
-| Twitch     |    `TWITCH`    |        Yes        |      Yes       |
-| Epic Games |  `EPIC_GAMES`  |        Yes        |       No       |
-| Reddit     |    `REDDIT`    |        Yes        |       No       |
+| Provider   | `ProviderType` | Usernames Mutable | Email Provided | 2FA Available* |
+|------------|:--------------:|:-----------------:|:--------------:|:--------------:|
+| Google     |    `GOOGLE`    |        No         |      Yes       |      Null      |
+| Discord    |   `DISCORD`    |        Yes        |      Yes       |      Yes       |
+| Twitter    |   `TWITTER`    |        Yes        |       No       |      Null      |
+| Chess.com  |    `CHESS`     |        Yes        |      Yes       |       No       |
+| Twitch     |    `TWITCH`    |        Yes        |      Yes       |      Null      |
+| Epic Games |  `EPIC_GAMES`  |        Yes        |       No       |      Null      |
+| Reddit     |    `REDDIT`    |        Yes        |       No       |      Null      |
+
+*Denotes whether you can see whether a user has enabled 2FA for a provider via Keyp's API. Null means the provider supports 2FA, but it can't be checked via Keyp's API
 
 ## Planned
 


### PR DESCRIPTION
Closes https://github.com/UseKeyp/keyp-app/issues/169

## Description
- Add a database entry for `mfa_enabled`

It seems you added this in the DB last month for Discord and it already is working for Discord login

<img width="219" alt="Screenshot 2023-04-21 at 5 28 34 PM" src="https://user-images.githubusercontent.com/47253537/233737514-75f6a1c9-c088-4e14-b522-66f8a3ff793c.png">

- Update the providers to include this data from their profile


Unfortunately there are currently no other providers that expose this info via their API. Here's the full list:

chess: no 2fa in platform
discord: already added
Epic games: not available via api (see api docs: https://dev.epicgames.com/docs/web-api-ref/authentication)
Google: not available via api (see here: https://stackoverflow.com/questions/63301129/how-to-discover-if-google-user-is-using-two-factor-authentication-through-oidc and here: https://stackoverflow.com/questions/45301632/google-oauth2-api-check-user-has-two-factor-authentication-not-gsuite)
reddit: not available via api (see https://www.reddit.com/dev/api)
twitch: not available via api (see https://dev.twitch.tv/docs/api/reference/)
twitter: not available via api: (see https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me)


- Update the docs for adding a new provider to include getting this info. Also include getting the email (false if no, true if yes, null if data is not provided)

Added these instructions to step 5 in your "add a provider" instructions: https://github.com/UseKeyp/keyp-app/issues/184

## Screenshots

Updated docs

<img width="1230" alt="Screenshot 2023-04-21 at 5 16 46 PM" src="https://user-images.githubusercontent.com/47253537/233737247-8fc5e4db-a8c2-47e8-a6bb-70b58c8c0480.png">


