### PR TITLE
Issue #83: SDK docs

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -5,10 +5,14 @@ sidebar_label: "Authentication"
 
 # Authentication
 
-To use the API in your app, you'll need to provide the `AccessToken` for a specific user:
+To use the API in your app, you'll need to provide the access token for a specific user. In this example, 
+we'll use a helper function from `@usekeyp/js-sdk` to do a token transfer:
 
 ```js
+const ACCESS_TOKEN = session.user.accessToken
+
 const data = {
+    accessToken: ACCESS_TOKEN,
     toUserUsername: "pi0neerpat#1337",
     toUserProviderType: "DISCORD",
     tokenAddress: '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063',
@@ -16,6 +20,12 @@ const data = {
     amount: '.01',
 }
 
+const res = await tokenTransfer(data)
+```
+
+Here's an example of a token transfer without the helper function:
+
+```js
 const ACCESS_TOKEN = session.user.accessToken
 const options = {
     headers: {
@@ -35,14 +45,26 @@ const res = await axios
     })
 ```
 
-### Get your `AccessToken`
+### Get your Access Token via UI
 
-An `AccessToken` for your account can be found in the the [Dev Portal](https://dev.UseKeyp.com). 
+An access token for your account can be found in the [Dev Portal](https://dev.UseKeyp.com). 
 
 ![Access Token](/img/dev-portal-access-token.png)
 
-Access Tokens are scoped to a single user, per a single application, per a single set of permissions.
+Access tokens are scoped to a single user, per a single application, per a single set of permissions.
 
-Your Access Token here is **limited to the Polygon network**, since the Dev Portal is built on Polygon.
+Your access token here is **limited to the Polygon network**, since the Dev Portal is built on Polygon.
 
 To use another network, you must create your own Keyp Application.
+
+### Get your Access Token via Session
+
+When using NextAuth.js, a user's access token can be found in the session.
+
+```js
+import { useSession } from "next-auth/react";
+
+const { data: session } = useSession();
+
+const ACCESS_TOKEN = session.user.accessToken
+```

--- a/docs/resources/js-sdk.md
+++ b/docs/resources/js-sdk.md
@@ -1,0 +1,109 @@
+---
+sidebar_position: 1
+sidebar_label: "@usekeyp/js-sdk"
+---
+
+# `@usekeyp/js-sdk`
+
+Keyp's SDK provides a simple interface for interacting with Keyp's API.
+
+Currently, the SDK supports the following:
+- Plugin for logging into Keyp and persisting session data with NextAuth.js
+- Helper function for signing in using Keyp and NextAuth.js
+- Helper function for ERC20 and ERC721 token transfers
+- Axios client for easily making requests to Keyp's API 
+
+## Usage 📖
+
+1.  Add package to your project:  
+    `yarn add @usekeyp/js-sdk`
+
+2. Choose from a variety of SDK plugins and helpers:
+
+Easy Keyp logins with NextAuth.js
+
+```js
+// pages/api/auth/[...nextauth].js
+import { KeypAuth } from "@usekeyp/js-sdk";
+import NextAuth from "next-auth";
+
+const NextAuthOptions = KeypAuth({
+    clientId: process.env.KEYP_CLIENT_ID, // From dev portal
+    secret: process.env.KEYP_COOKIE_SECRET, // Random string
+    redirectUrl: "http://localhost:3000/api/auth/callback/keyp",
+});
+
+export default NextAuth(NextAuthOptions);
+```
+
+Easy user sign in using Keyp and NextAuth.js
+
+```js
+import { signInKeyp } from "@usekeyp/js-sdk"
+
+export default function SignInPage() {
+    return (
+        <div>
+        <button onClick={() => signInKeyp("GOOGLE")}>Sign in with Google</button>
+        <button onClick={() => signInKeyp("DISCORD")}>Sign in with Discord</button>
+        </div>
+    )
+}
+```
+
+Easy token transfers
+
+```js
+const ACCESS_TOKEN = session.user.accessToken
+
+const data = {
+    accessToken: ACCESS_TOKEN,
+    toUserUsername: "pi0neerpat#1337",
+    toUserProviderType: "DISCORD",
+    tokenAddress: '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063',
+    tokenType: 'ERC20',
+    amount: '.01',
+}
+
+const res = await tokenTransfer(data)
+```
+
+Easy API requests with keypClient, a helper for your axios requests
+
+```js
+ useEffect(() => {
+    const ACCESS_TOKEN = session?.user.accessToken;
+    const userId = session?.user.id;
+
+    const options = {
+        headers: {
+            Authorization: `Bearer ${ACCESS_TOKEN}`,
+        },
+    };
+
+    const firstRequest = `/users/${userId}/balance`;
+    const secondRequest = `/users/${userId}/balance/${supportedAssets.DAI}`;
+
+    axios
+        .all([
+            keypClient.get(firstRequest, options),
+            keypClient.get(secondRequest, options),
+        ])
+        .then(
+            axios.spread((firstResponse, secondResponse) => {
+                let DAI = Object.values(secondResponse.data);
+                setAssets({ ...firstResponse.data, DAI: DAI[0] });
+                setIsLoading(false);
+            })
+        )
+        .catch((error) => console.error(error));
+}, []);
+```
+
+
+## Resources 🧑‍💻
+
+- [SDK Repository](https://github.com/UseKeyp/usekeyp-js-sdk)
+- [NextAuth.js](https://next-auth.js.org/)
+
+More functionality coming soon!


### PR DESCRIPTION
Closes #83 

## Description
- [X] Update the authenticate with next.js section to use the SDK 
- [X] Update the API section to show first how to call the API with the SDK
- [X] Update the Login Portal page code to use the SDK for logging in
- [X] add a new page under `resources` similar to the ui-kit, which has some basic info about the SDK. We can talk about what needs to go here later. Right now it should just point to the repo.

## Screenshots

getting started: replaced large [...nextauth].ts boilerplate file to use SDK code 

<img width="1156" alt="quick start" src="https://github.com/UseKeyp/usekeyp-docs/assets/47253537/df48cdd4-fc9c-4955-ba0c-e2dd4da6c0dd">

getting started: added signInKeyp helper from SDK to login page

<img width="1012" alt="login page quick start" src="https://github.com/UseKeyp/usekeyp-docs/assets/47253537/6b8814b1-a6b9-45f0-98f1-502a9cdd52dc">

API section: show how to use the API with and without the SDK:

<img width="1154" alt="sdk auth" src="https://github.com/UseKeyp/usekeyp-docs/assets/47253537/83a23ea8-ef36-4ca6-9b0f-3d0c578aeac4">

new usekeyp/js-sdk page under resources:

https://github.com/UseKeyp/usekeyp-docs/assets/47253537/d2bb3ea9-0b89-46c1-978e-5a55c9ba8039

